### PR TITLE
Simplify Sleep helper to function

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,9 @@ led.blink(250, times=3)
 
 ### `Reduino.Time.Sleep`
 
-| Member                         | Description                                                |
-| ------------------------------ | ---------------------------------------------------------- |
-| `Sleep(ms, sleep_func=None)`   | Delay helper; custom `sleep_func` is injectable for tests. |
-| `.seconds`                     | Duration exposed in seconds.                               |             
+| Member                       | Description                                                |
+| ---------------------------- | ---------------------------------------------------------- |
+| `Sleep(ms, sleep_func=None)` | Delay helper; custom `sleep_func` is injectable for tests. |
 
 **Example**
 

--- a/src/Reduino/Actuators.py
+++ b/src/Reduino/Actuators.py
@@ -76,9 +76,9 @@ class Led:
 
         for _ in range(times):
             self.on()
-            Sleep(duration_ms).wait()
+            Sleep(duration_ms)
             self.off()
-            Sleep(duration_ms).wait()
+            Sleep(duration_ms)
 
     def fade_in(self, step: int = 5, delay_ms: int = 10) -> None:
         """Gradually increase brightness towards 255."""
@@ -91,7 +91,7 @@ class Led:
         current = max(0, min(255, int(self.brightness)))
         while current < 255:
             self.set_brightness(current)
-            Sleep(delay_ms).wait()
+            Sleep(delay_ms)
             current = min(255, current + step)
         self.set_brightness(255)
 
@@ -106,7 +106,7 @@ class Led:
         current = max(0, min(255, int(self.brightness)))
         while current > 0:
             self.set_brightness(current)
-            Sleep(delay_ms).wait()
+            Sleep(delay_ms)
             current = max(0, current - step)
         self.set_brightness(0)
 
@@ -129,7 +129,7 @@ class Led:
                 self.set_brightness(int(entry))
 
             if index != len(pattern_list) - 1:
-                Sleep(delay_ms).wait()
+                Sleep(delay_ms)
 
     def __repr__(self) -> str:  # pragma: no cover - debug helper
         return (

--- a/src/Reduino/Time.py
+++ b/src/Reduino/Time.py
@@ -6,48 +6,27 @@ from typing import Callable
 import time
 
 
-class Sleep:
-    """Represent and optionally execute a millisecond-scale delay."""
+def Sleep(
+    duration: int | float,
+    *,
+    sleep_func: Callable[[float], None] | None = None,
+) -> None:
+    """Block for ``duration`` milliseconds using ``sleep_func``.
 
-    def __init__(
-        self,
-        duration: int | float,
-        *,
-        sleep_func: Callable[[float], None] | None = None,
-    ) -> None:
-        """Create a delay helper.
+    Parameters
+    ----------
+    duration:
+        The requested delay in milliseconds.  Negative values are rejected
+        because they cannot be represented on the Arduino side either.
+    sleep_func:
+        Injectable callable used to perform the actual wait.  Defaults to
+        :func:`time.sleep`.
+    """
 
-        Parameters
-        ----------
-        duration:
-            The requested delay in milliseconds.  Negative values are rejected
-            because they cannot be represented on the Arduino side either.
-        sleep_func:
-            Injectable callable used to perform the actual wait when :meth:`wait`
-            (or :meth:`__call__`) is invoked.  Defaults to :func:`time.sleep`.
-        """
+    if duration < 0:
+        raise ValueError("duration must be non-negative")
 
-        if duration < 0:
-            raise ValueError("duration must be non-negative")
-
-        self.duration_ms = float(duration)
-        self._sleep = sleep_func or time.sleep
-
-    @property
-    def seconds(self) -> float:
-        """Return the configured delay expressed in seconds."""
-
-        return self.duration_ms / 1000.0
-
-    def wait(self) -> None:
-        """Block for the configured duration using the injected sleep function."""
-
-        self._sleep(self.seconds)
-
-    def __call__(self) -> None:
-        """Calling the instance is equivalent to :meth:`wait`."""
-
-        self.wait()
-
-    def __repr__(self) -> str:  # pragma: no cover - debug helper
-        return f"Sleep(duration_ms={self.duration_ms})"
+    milliseconds = float(duration)
+    seconds = milliseconds / 1000.0
+    sleeper = sleep_func or time.sleep
+    sleeper(seconds)

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -8,8 +8,9 @@ from Reduino.Time import Sleep
 
 
 def test_sleep_converts_to_seconds():
-    sleep = Sleep(250)
-    assert pytest.approx(sleep.seconds) == 0.25
+    calls: list[float] = []
+    Sleep(250, sleep_func=calls.append)
+    assert pytest.approx(calls) == [0.25]
 
 
 def test_sleep_validates_duration():
@@ -17,22 +18,12 @@ def test_sleep_validates_duration():
         Sleep(-1)
 
 
-def test_sleep_wait_uses_injected_callable():
+def test_sleep_uses_injected_callable():
     calls: list[float] = []
 
     def fake_sleep(value: float) -> None:
         calls.append(value)
 
-    sleeper = Sleep(500, sleep_func=fake_sleep)
-    sleeper.wait()
+    Sleep(500, sleep_func=fake_sleep)
 
     assert calls == [0.5]
-
-
-def test_sleep_is_callable():
-    calls: list[float] = []
-
-    sleeper = Sleep(1000, sleep_func=calls.append)
-    sleeper()
-
-    assert calls == [1.0]


### PR DESCRIPTION
## Summary
- replace the Sleep class with a function-based helper that sleeps for a millisecond duration
- update actuator helpers and documentation to use the new Sleep function
- refresh unit tests to cover the streamlined Sleep behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_6901377910f883268dba2397be860a5c