### PR TITLE
Refactor actuator helpers into package

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ actuators or sensors to the transpiler.
   src/Reduino/
     transpile/      # Parser, AST, and emitter
     toolchain/      # PlatformIO helpers
-    Actuators.py    # Runtime helpers mirroring generated code
+    Actuators/      # Runtime helpers mirroring generated code
     Time.py         # Timing helpers for tests/examples
   ```
 - Prefer descriptive naming (`LedDecl`, `Sleep`, `VarAssign`) and keep parser/emitter logic

--- a/src/Reduino/Actuators/Led.py
+++ b/src/Reduino/Actuators/Led.py
@@ -3,8 +3,13 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+import sys
 
-from Reduino.Time import Sleep
+
+def _sleep(*args, **kwargs):
+    """Proxy to the package-level ``Sleep`` so monkeypatching works."""
+
+    return getattr(sys.modules[__package__], "Sleep")(*args, **kwargs)
 
 
 class Led:
@@ -76,9 +81,9 @@ class Led:
 
         for _ in range(times):
             self.on()
-            Sleep(duration_ms)
+            _sleep(duration_ms)
             self.off()
-            Sleep(duration_ms)
+            _sleep(duration_ms)
 
     def fade_in(self, step: int = 5, delay_ms: int = 10) -> None:
         """Gradually increase brightness towards 255."""
@@ -91,7 +96,7 @@ class Led:
         current = max(0, min(255, int(self.brightness)))
         while current < 255:
             self.set_brightness(current)
-            Sleep(delay_ms)
+            _sleep(delay_ms)
             current = min(255, current + step)
         self.set_brightness(255)
 
@@ -106,7 +111,7 @@ class Led:
         current = max(0, min(255, int(self.brightness)))
         while current > 0:
             self.set_brightness(current)
-            Sleep(delay_ms)
+            _sleep(delay_ms)
             current = max(0, current - step)
         self.set_brightness(0)
 
@@ -129,7 +134,7 @@ class Led:
                 self.set_brightness(int(entry))
 
             if index != len(pattern_list) - 1:
-                Sleep(delay_ms)
+                _sleep(delay_ms)
 
     def __repr__(self) -> str:  # pragma: no cover - debug helper
         return (

--- a/src/Reduino/Actuators/__init__.py
+++ b/src/Reduino/Actuators/__init__.py
@@ -1,0 +1,11 @@
+"""Runtime actuator helpers exposed by the public API."""
+
+from __future__ import annotations
+
+from Reduino.Time import Sleep
+
+__all__ = ["Sleep"]
+
+from .Led import Led
+
+__all__ = [*__all__, "Led"]


### PR DESCRIPTION
## Summary
- move the LED runtime helper into a dedicated `Actuators` package while preserving imports
- add a package initializer that re-exports `Led` and `Sleep` for backward compatibility
- update contributor documentation to reflect the new module layout

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_690281ba61f883269f9152a6e5fac696