### PR TITLE
Add PWMDriver actuator and transpiler support with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@
     * [Buzzer](#buzzer)
     * [Servo](#servo)
     * [DC Motor](#dc-motor)
+    * [PWM Driver](#pwm-driver)
   * [Displays](#displays)
     * [LCD](#lcd)
   * [Sensors](#sensors)
@@ -334,6 +335,43 @@ motor.ramp(-1.0, duration_ms=800)
 sleep(250)
 motor.stop()
 ```
+
+---
+
+#### PWM Driver
+
+| Method | Description |
+| ------ | ----------- |
+| `PWMDriver(i2c_addr=0x40, frequency_hz=50.0, channels=16, resolution=4095)` | Create an I²C PWM expander abstraction (PCA9685-style defaults). |
+| `set_frequency(frequency_hz)` / `get_frequency()` | Set/read the shared PWM update frequency (applies to all channels). |
+| `set_duty(channel, value)` / `get_duty(channel)` | Write/read raw duty counts in the `0..resolution` range. |
+| `set_level(channel, value)` / `get_level(channel)` | Write/read normalized duty in the `0.0..1.0` range. |
+| `off(channel)` / `all_off()` | Turn a channel off, or all channels off. |
+
+**Example**
+
+```python
+from Reduino import target
+target("COM3")
+
+from Reduino.Actuators import PWMDriver
+from Reduino.Utils import sleep
+
+driver = PWMDriver()  # defaults: 0x40, 50Hz, 16 channels, 12-bit (4095)
+driver.set_frequency(60)
+driver.set_duty(0, 2048)     # ~50% raw duty
+driver.set_level(1, 0.25)    # 25% normalized duty
+
+duty = driver.get_duty(0)
+level = driver.get_level(1)
+freq = driver.get_frequency()
+
+sleep(200)
+driver.all_off()
+```
+
+> [!NOTE]
+> During transpilation, Reduino injects `Wire` and `Adafruit_PWMServoDriver` includes automatically when `PWMDriver` is used.
 
 ---
 

--- a/src/Reduino/Actuators/PWMDriver.py
+++ b/src/Reduino/Actuators/PWMDriver.py
@@ -15,7 +15,7 @@ class PWMDriver:
         self,
         i2c_addr: int = 0x40,
         *,
-        frequency_hz: float = 1000.0,
+        frequency_hz: float = 50.0,
         channels: int = 16,
         resolution: int = 4095,
     ) -> None:

--- a/src/Reduino/Actuators/PWMDriver.py
+++ b/src/Reduino/Actuators/PWMDriver.py
@@ -1,0 +1,112 @@
+"""In-memory model of an I2C PWM driver (e.g. PCA9685)."""
+
+from __future__ import annotations
+
+
+class PWMDriver:
+    """High-level abstraction of a multi-channel PWM driver.
+
+    The helper mirrors an I2C PWM expander style API while remaining hardware
+    agnostic for host-side tests. Duty values are represented using a
+    ``0..resolution`` integer range and normalized channel levels use ``0..1``.
+    """
+
+    def __init__(
+        self,
+        i2c_addr: int = 0x40,
+        *,
+        frequency_hz: float = 1000.0,
+        channels: int = 16,
+        resolution: int = 4095,
+    ) -> None:
+        if not isinstance(i2c_addr, int):
+            raise TypeError("i2c_addr must be an integer")
+        if not 0 <= i2c_addr <= 0x7F:
+            raise ValueError("i2c_addr must be between 0x00 and 0x7F")
+        if channels <= 0:
+            raise ValueError("channels must be positive")
+        if resolution <= 0:
+            raise ValueError("resolution must be positive")
+
+        self.i2c_addr = i2c_addr
+        self.channels = int(channels)
+        self.resolution = int(resolution)
+        self._frequency_hz = 0.0
+        self._duty = [0] * self.channels
+        self.set_frequency(float(frequency_hz))
+
+    def _validate_channel(self, channel: int) -> int:
+        if not isinstance(channel, int):
+            raise TypeError("channel must be an integer")
+        if not 0 <= channel < self.channels:
+            raise ValueError("channel out of range")
+        return channel
+
+    def set_frequency(self, frequency_hz: float) -> None:
+        """Set the PWM update frequency in hertz."""
+
+        try:
+            value = float(frequency_hz)
+        except (TypeError, ValueError) as exc:
+            raise TypeError("frequency_hz must be a number") from exc
+        if value <= 0:
+            raise ValueError("frequency_hz must be positive")
+        self._frequency_hz = value
+
+    def get_frequency(self) -> float:
+        """Return the configured PWM frequency in hertz."""
+
+        return self._frequency_hz
+
+    def set_duty(self, channel: int, value: int) -> None:
+        """Set one channel duty cycle using ``0..resolution`` scale."""
+
+        index = self._validate_channel(channel)
+        if not isinstance(value, int):
+            raise TypeError("duty value must be an integer")
+        if not 0 <= value <= self.resolution:
+            raise ValueError(f"duty value must be between 0 and {self.resolution}")
+        self._duty[index] = int(value)
+
+    def get_duty(self, channel: int) -> int:
+        """Return the duty value for ``channel``."""
+
+        return self._duty[self._validate_channel(channel)]
+
+    def set_level(self, channel: int, value: float) -> None:
+        """Set a channel using a normalized level in the ``0..1`` range."""
+
+        try:
+            level = float(value)
+        except (TypeError, ValueError) as exc:
+            raise TypeError("level must be a number") from exc
+        if not 0.0 <= level <= 1.0:
+            raise ValueError("level must be between 0.0 and 1.0")
+        duty = int(round(level * self.resolution))
+        self.set_duty(channel, duty)
+
+    def get_level(self, channel: int) -> float:
+        """Return a channel's normalized level in the ``0..1`` range."""
+
+        return self.get_duty(channel) / float(self.resolution)
+
+    def off(self, channel: int) -> None:
+        """Set one channel fully off."""
+
+        self.set_duty(channel, 0)
+
+    def all_off(self) -> None:
+        """Turn all channels off."""
+
+        for channel in range(self.channels):
+            self._duty[channel] = 0
+
+    def __repr__(self) -> str:  # pragma: no cover - debug helper
+        return (
+            "PWMDriver("
+            f"i2c_addr=0x{self.i2c_addr:02X}, "
+            f"frequency_hz={self._frequency_hz:.2f}, "
+            f"channels={self.channels}, "
+            f"resolution={self.resolution}"
+            ")"
+        )

--- a/src/Reduino/Actuators/__init__.py
+++ b/src/Reduino/Actuators/__init__.py
@@ -11,5 +11,6 @@ from .DCMotor import DCMotor
 from .Led import Led
 from .RGBLed import RGBLed
 from .Servo import Servo
+from .PWMDriver import PWMDriver
 
-__all__ = [*__all__, "Buzzer", "DCMotor", "Led", "RGBLed", "Servo"]
+__all__ = [*__all__, "Buzzer", "DCMotor", "Led", "RGBLed", "Servo", "PWMDriver"]

--- a/src/Reduino/__init__.py
+++ b/src/Reduino/__init__.py
@@ -16,7 +16,7 @@ from Reduino.toolchain.pio import (
     validate_platform_board,
     write_project,
 )
-from Reduino.transpile.ast import LCDDecl, Program, ServoDecl
+from Reduino.transpile.ast import LCDDecl, PWMDriverDecl, Program, ServoDecl
 from Reduino.transpile.emitter import emit
 from Reduino.transpile.parser import parse
 
@@ -60,6 +60,8 @@ def _collect_required_libraries(program: Program) -> List[str]:
     requirements: List[str] = []
     if _program_contains(program, ServoDecl):
         requirements.append("Servo")
+    if _program_contains(program, PWMDriverDecl):
+        requirements.append("adafruit/Adafruit PWM Servo Driver Library")
     lcd_interfaces: set[str] = set()
 
     def _visit(value: object) -> None:

--- a/src/Reduino/transpile/ast.py
+++ b/src/Reduino/transpile/ast.py
@@ -462,6 +462,58 @@ class DCMotorRunFor:
 
 
 @dataclass
+class PWMDriverDecl:
+    """Declare an I2C PWM driver (e.g. PCA9685)."""
+
+    name: str
+    i2c_addr: Union[int, str] = 0x40
+    frequency_hz: Union[float, int, str] = 1000.0
+    channels: Union[int, str] = 16
+    resolution: Union[int, str] = 4095
+
+
+@dataclass
+class PWMDriverSetFrequency:
+    """Set the PWM driver base frequency."""
+
+    name: str
+    frequency_hz: Union[float, int, str]
+
+
+@dataclass
+class PWMDriverSetDuty:
+    """Set a PWM channel using raw duty counts."""
+
+    name: str
+    channel: Union[int, str]
+    value: Union[int, str]
+
+
+@dataclass
+class PWMDriverSetLevel:
+    """Set a PWM channel using a normalized level in ``0..1``."""
+
+    name: str
+    channel: Union[int, str]
+    value: Union[float, int, str]
+
+
+@dataclass
+class PWMDriverOff:
+    """Turn one PWM channel off."""
+
+    name: str
+    channel: Union[int, str]
+
+
+@dataclass
+class PWMDriverAllOff:
+    """Turn all PWM channels off."""
+
+    name: str
+
+
+@dataclass
 class Sleep:
     """Delay execution for ``ms`` milliseconds."""
 

--- a/src/Reduino/transpile/emitter.py
+++ b/src/Reduino/transpile/emitter.py
@@ -57,6 +57,12 @@ from .ast import (
     DCMotorInvert,
     DCMotorRamp,
     DCMotorRunFor,
+    PWMDriverDecl,
+    PWMDriverSetFrequency,
+    PWMDriverSetDuty,
+    PWMDriverSetLevel,
+    PWMDriverOff,
+    PWMDriverAllOff,
     InfraredDigitalDecl,
     PotentiometerDecl,
     ReturnStmt,
@@ -802,6 +808,7 @@ def _emit_block(
     servo_state: Dict[str, Dict[str, str]],
     dc_motor_pins: Dict[str, Tuple[Union[int, str], Union[int, str], Union[int, str]]],
     dc_motor_state: Dict[str, Dict[str, str]],
+    pwm_driver_state: Dict[str, Dict[str, str]],
     lcd_decls: Dict[str, LCDDecl],
     lcd_state: Dict[str, Dict[str, str]],
     lcd_animations: Dict[str, List[Tuple[str, str]]],
@@ -867,6 +874,20 @@ def _emit_block(
             info["speed"],
             info["inverted"],
             info["mode"],
+        )
+
+    def _ensure_pwm_tracking(name: str) -> Dict[str, str]:
+        return pwm_driver_state.setdefault(
+            name,
+            {
+                "object": f"__redu_pwm_{name}",
+                "frequency": f"__pwm_frequency_{name}",
+                "channels": f"__pwm_channels_{name}",
+                "resolution": f"__pwm_resolution_{name}",
+                "state": f"__pwm_duty_{name}",
+                "getter_duty": f"__redu_pwm_get_duty_{name}",
+                "getter_level": f"__redu_pwm_get_level_{name}",
+            },
         )
 
     def _emit_motor_drive_lines(
@@ -1080,6 +1101,7 @@ def _emit_block(
                     servo_state,
                     dc_motor_pins,
                     dc_motor_state,
+                    pwm_driver_state,
                     lcd_decls,
                     lcd_state,
                     lcd_animations,
@@ -1156,6 +1178,7 @@ def _emit_block(
                     servo_state,
                     dc_motor_pins,
                     dc_motor_state,
+                    pwm_driver_state,
                     lcd_decls,
                     lcd_state,
                     lcd_animations,
@@ -1184,11 +1207,13 @@ def _emit_block(
                         rgb_led_colors,
                         ultrasonic_decls,
                         potentiometer_decls,
+                        infrared_digital_decls,
                         button_decls,
                         servo_decls,
                         servo_state,
                         dc_motor_pins,
                         dc_motor_state,
+                        pwm_driver_state,
                         lcd_decls,
                         lcd_state,
                         lcd_animations,
@@ -1225,6 +1250,7 @@ def _emit_block(
                     servo_state,
                     dc_motor_pins,
                     dc_motor_state,
+                    pwm_driver_state,
                     lcd_decls,
                     lcd_state,
                     lcd_animations,
@@ -1264,6 +1290,7 @@ def _emit_block(
                     servo_state,
                     dc_motor_pins,
                     dc_motor_state,
+                    pwm_driver_state,
                     lcd_decls,
                     lcd_state,
                     lcd_animations,
@@ -1300,6 +1327,7 @@ def _emit_block(
                     servo_state,
                     dc_motor_pins,
                     dc_motor_state,
+                    pwm_driver_state,
                     lcd_decls,
                     lcd_state,
                     lcd_animations,
@@ -1337,11 +1365,13 @@ def _emit_block(
                         rgb_led_colors,
                         ultrasonic_decls,
                         potentiometer_decls,
+                        infrared_digital_decls,
                         button_decls,
                         servo_decls,
                         servo_state,
                         dc_motor_pins,
                         dc_motor_state,
+                        pwm_driver_state,
                         lcd_decls,
                         lcd_state,
                         lcd_animations,
@@ -1962,6 +1992,92 @@ def _emit_block(
             lines.append(f"{indent}}}")
             continue
 
+        if isinstance(node, PWMDriverSetFrequency):
+            info = _ensure_pwm_tracking(node.name)
+            lines.append(f"{indent}{{")
+            lines.append(
+                f"{indent}  float __redu_freq = static_cast<float>({_emit_expr(node.frequency_hz)});"
+            )
+            lines.append(f"{indent}  if (__redu_freq <= 0.0f) {{ __redu_freq = 1.0f; }}")
+            lines.append(f"{indent}  {info['frequency']} = __redu_freq;")
+            lines.append(f"{indent}  {info['object']}.setPWMFreq(__redu_freq);")
+            lines.append(f"{indent}}}")
+            continue
+
+        if isinstance(node, PWMDriverSetDuty):
+            info = _ensure_pwm_tracking(node.name)
+            lines.append(f"{indent}{{")
+            lines.append(
+                f"{indent}  int __redu_channel = static_cast<int>({_emit_expr(node.channel)});"
+            )
+            lines.append(
+                f"{indent}  int __redu_value = static_cast<int>({_emit_expr(node.value)});"
+            )
+            lines.append(f"{indent}  if (__redu_channel < 0) {{ __redu_channel = 0; }}")
+            lines.append(
+                f"{indent}  if (__redu_channel >= {info['channels']}) {{ __redu_channel = {info['channels']} - 1; }}"
+            )
+            lines.append(f"{indent}  if (__redu_value < 0) {{ __redu_value = 0; }}")
+            lines.append(
+                f"{indent}  if (__redu_value > {info['resolution']}) {{ __redu_value = {info['resolution']}; }}"
+            )
+            lines.append(f"{indent}  {info['state']}[__redu_channel] = __redu_value;")
+            lines.append(
+                f"{indent}  {info['object']}.setPWM(__redu_channel, 0, static_cast<int>(__redu_value));"
+            )
+            lines.append(f"{indent}}}")
+            continue
+
+        if isinstance(node, PWMDriverSetLevel):
+            info = _ensure_pwm_tracking(node.name)
+            lines.append(f"{indent}{{")
+            lines.append(
+                f"{indent}  int __redu_channel = static_cast<int>({_emit_expr(node.channel)});"
+            )
+            lines.append(
+                f"{indent}  float __redu_level = static_cast<float>({_emit_expr(node.value)});"
+            )
+            lines.append(f"{indent}  if (__redu_channel < 0) {{ __redu_channel = 0; }}")
+            lines.append(
+                f"{indent}  if (__redu_channel >= {info['channels']}) {{ __redu_channel = {info['channels']} - 1; }}"
+            )
+            lines.append(f"{indent}  if (__redu_level < 0.0f) {{ __redu_level = 0.0f; }}")
+            lines.append(f"{indent}  if (__redu_level > 1.0f) {{ __redu_level = 1.0f; }}")
+            lines.append(
+                f"{indent}  int __redu_value = static_cast<int>((__redu_level * static_cast<float>({info['resolution']})) + 0.5f);"
+            )
+            lines.append(f"{indent}  {info['state']}[__redu_channel] = __redu_value;")
+            lines.append(
+                f"{indent}  {info['object']}.setPWM(__redu_channel, 0, static_cast<int>(__redu_value));"
+            )
+            lines.append(f"{indent}}}")
+            continue
+
+        if isinstance(node, PWMDriverOff):
+            info = _ensure_pwm_tracking(node.name)
+            lines.append(f"{indent}{{")
+            lines.append(
+                f"{indent}  int __redu_channel = static_cast<int>({_emit_expr(node.channel)});"
+            )
+            lines.append(f"{indent}  if (__redu_channel < 0) {{ __redu_channel = 0; }}")
+            lines.append(
+                f"{indent}  if (__redu_channel >= {info['channels']}) {{ __redu_channel = {info['channels']} - 1; }}"
+            )
+            lines.append(f"{indent}  {info['state']}[__redu_channel] = 0;")
+            lines.append(f"{indent}  {info['object']}.setPWM(__redu_channel, 0, 0);")
+            lines.append(f"{indent}}}")
+            continue
+
+        if isinstance(node, PWMDriverAllOff):
+            info = _ensure_pwm_tracking(node.name)
+            lines.append(
+                f"{indent}for (int __redu_channel = 0; __redu_channel < {info['channels']}; ++__redu_channel) {{"
+            )
+            lines.append(f"{indent}  {info['state']}[__redu_channel] = 0;")
+            lines.append(f"{indent}  {info['object']}.setPWM(__redu_channel, 0, 0);")
+            lines.append(f"{indent}}}")
+            continue
+
         if isinstance(node, LedOn):
             pin_code, state_var, brightness_var = _ensure_led_tracking(node.name)
             lines.append(f"{indent}{state_var} = true;")
@@ -2479,6 +2595,8 @@ def emit(ast: Program) -> str:
     servo_used = False
     dc_motor_pins: Dict[str, Tuple[Union[int, str], Union[int, str], Union[int, str]]] = {}
     dc_motor_state: Dict[str, Dict[str, str]] = {}
+    pwm_driver_state: Dict[str, Dict[str, str]] = {}
+    pwm_driver_used = False
     lcd_decls: Dict[str, LCDDecl] = {}
     lcd_state: Dict[str, Dict[str, str]] = {}
     lcd_animations: Dict[str, List[Tuple[str, str]]] = {}
@@ -2644,6 +2762,63 @@ def emit(ast: Program) -> str:
         lcd_animations.setdefault(node.name, [])
         return info
 
+    def _ensure_pwm_globals(node: PWMDriverDecl) -> Dict[str, str]:
+        nonlocal pwm_driver_used
+        pwm_driver_used = True
+        info = pwm_driver_state.setdefault(
+            node.name,
+            {
+                "object": f"__redu_pwm_{node.name}",
+                "frequency": f"__pwm_frequency_{node.name}",
+                "channels": f"__pwm_channels_{node.name}",
+                "resolution": f"__pwm_resolution_{node.name}",
+                "state": f"__pwm_duty_{node.name}",
+                "getter_duty": f"__redu_pwm_get_duty_{node.name}",
+                "getter_level": f"__redu_pwm_get_level_{node.name}",
+            },
+        )
+        addr_expr = _emit_expr(node.i2c_addr)
+        object_line = f"Adafruit_PWMServoDriver {info['object']}({addr_expr});"
+        if object_line not in globals_:
+            globals_.append(object_line)
+
+        frequency_line = (
+            f"float {info['frequency']} = static_cast<float>({_emit_expr(node.frequency_hz)});"
+        )
+        channels_line = (
+            f"int {info['channels']} = static_cast<int>({_emit_expr(node.channels)});"
+        )
+        resolution_line = (
+            f"int {info['resolution']} = static_cast<int>({_emit_expr(node.resolution)});"
+        )
+        state_line = f"int *{info['state']} = nullptr;"
+        getter_duty_line = (
+            f"int {info['getter_duty']}(int channel) {{"
+            f" if ({info['channels']} <= 0 || {info['state']} == nullptr) return 0;"
+            " if (channel < 0) channel = 0;"
+            f" if (channel >= {info['channels']}) channel = {info['channels']} - 1;"
+            f" return {info['state']}[channel];"
+            " }"
+        )
+        getter_level_line = (
+            f"float {info['getter_level']}(int channel) {{"
+            f" if ({info['resolution']} <= 0) return 0.0f;"
+            f" return static_cast<float>({info['getter_duty']}(channel)) / static_cast<float>({info['resolution']});"
+            " }"
+        )
+
+        for line in (
+            frequency_line,
+            channels_line,
+            resolution_line,
+            state_line,
+            getter_duty_line,
+            getter_level_line,
+        ):
+            if line not in globals_:
+                globals_.append(line)
+        return info
+
     for node in (setup_body or []):
         if isinstance(node, ButtonDecl):
             button_decls[node.name] = node
@@ -2713,6 +2888,23 @@ def emit(ast: Program) -> str:
             setup_lines.append(f"  digitalWrite({in1_expr}, LOW);")
             setup_lines.append(f"  digitalWrite({in2_expr}, LOW);")
             setup_lines.append(f"  analogWrite({enable_expr}, 0);")
+            continue
+
+        if isinstance(node, PWMDriverDecl):
+            info = _ensure_pwm_globals(node)
+            setup_lines.append(f"  {info['object']}.begin();")
+            setup_lines.append(
+                f"  if ({info['frequency']} <= 0.0f) {{ {info['frequency']} = 1.0f; }}"
+            )
+            setup_lines.append(f"  {info['object']}.setPWMFreq({info['frequency']});")
+            setup_lines.append(
+                f"  if ({info['channels']} <= 0) {{ {info['channels']} = 1; }}"
+            )
+            setup_lines.append(
+                f"  if ({info['resolution']} <= 0) {{ {info['resolution']} = 1; }}"
+            )
+            setup_lines.append(f"  if ({info['state']} != nullptr) {{ delete[] {info['state']}; }}")
+            setup_lines.append(f"  {info['state']} = new int[{info['channels']}]();")
             continue
 
         if isinstance(node, LCDDecl):
@@ -2895,6 +3087,23 @@ def emit(ast: Program) -> str:
             setup_lines.append(f"  analogWrite({enable_expr}, 0);")
             continue
 
+        if isinstance(node, PWMDriverDecl):
+            info = _ensure_pwm_globals(node)
+            setup_lines.append(f"  {info['object']}.begin();")
+            setup_lines.append(
+                f"  if ({info['frequency']} <= 0.0f) {{ {info['frequency']} = 1.0f; }}"
+            )
+            setup_lines.append(f"  {info['object']}.setPWMFreq({info['frequency']});")
+            setup_lines.append(
+                f"  if ({info['channels']} <= 0) {{ {info['channels']} = 1; }}"
+            )
+            setup_lines.append(
+                f"  if ({info['resolution']} <= 0) {{ {info['resolution']} = 1; }}"
+            )
+            setup_lines.append(f"  if ({info['state']} != nullptr) {{ delete[] {info['state']}; }}")
+            setup_lines.append(f"  {info['state']} = new int[{info['channels']}]();")
+            continue
+
         if isinstance(node, LedDecl):
             state_var = f"__state_{node.name}"
             bright_var = f"__brightness_{node.name}"
@@ -2995,6 +3204,7 @@ def emit(ast: Program) -> str:
             servo_state,
             dc_motor_pins,
             dc_motor_state,
+            pwm_driver_state,
             lcd_decls,
             lcd_state,
             lcd_animations,
@@ -3030,6 +3240,7 @@ def emit(ast: Program) -> str:
                     servo_state,
                     dc_motor_pins,
                     dc_motor_state,
+                    pwm_driver_state,
                     lcd_decls,
                     lcd_state,
                     lcd_animations,
@@ -3062,6 +3273,7 @@ def emit(ast: Program) -> str:
             servo_state,
             dc_motor_pins,
             dc_motor_state,
+            pwm_driver_state,
             lcd_decls,
             lcd_state,
             lcd_animations,
@@ -3103,6 +3315,7 @@ def emit(ast: Program) -> str:
             servo_state,
             dict(dc_motor_pins),
             {name: dict(info) for name, info in dc_motor_state.items()},
+            {name: dict(info) for name, info in pwm_driver_state.items()},
             dict(lcd_decls),
             {name: dict(info) for name, info in lcd_state.items()},
             {name: [(var, kind) for var, kind in values] for name, values in lcd_animations.items()},
@@ -3167,6 +3380,8 @@ def emit(ast: Program) -> str:
     parts: List[str] = [HEADER]
     if servo_used:
         parts.append("#include <Servo.h>\n\n")
+    if pwm_driver_used:
+        parts.append("#include <Wire.h>\n#include <Adafruit_PWMServoDriver.h>\n\n")
     if lcd_parallel_used:
         parts.append("#include <LiquidCrystal.h>\n\n")
     if lcd_i2c_used:

--- a/src/Reduino/transpile/parser.py
+++ b/src/Reduino/transpile/parser.py
@@ -3300,7 +3300,7 @@ def _parse_simple_lines(
             name, args_src = m.group(1), m.group(2)
             i2c_addr = _resolve_numeric_arg(_extract_call_argument(args_src, keyword="i2c_addr"), 0x40)
             frequency_hz = _resolve_float_arg(
-                _extract_call_argument(args_src, keyword="frequency_hz"), 1000.0
+                _extract_call_argument(args_src, keyword="frequency_hz"), 50.0
             )
             channels = _resolve_numeric_arg(_extract_call_argument(args_src, keyword="channels"), 16)
             resolution = _resolve_numeric_arg(_extract_call_argument(args_src, keyword="resolution"), 4095)
@@ -3999,7 +3999,7 @@ def _parse_simple_lines(
                 body.append(
                     PWMDriverSetFrequency(
                         name=name,
-                        frequency_hz=_resolve_float_arg(freq_arg, 1000.0),
+                        frequency_hz=_resolve_float_arg(freq_arg, 50.0),
                     )
                 )
                 i += 1

--- a/src/Reduino/transpile/parser.py
+++ b/src/Reduino/transpile/parser.py
@@ -1671,8 +1671,11 @@ def _parse_function(
     child_ctx: Dict[str, object] = dict(ctx)
     child_ctx["vars"] = dict(ctx.get("vars", {}))
     child_ctx["var_types"] = dict(ctx.get("var_types", {}))
-    child_ctx["var_declared"] = set(ctx.get("var_declared", set()))
-    child_ctx["_base_declared"] = set(child_ctx["var_declared"])
+    # Function-local assignments should start from a clean declaration scope.
+    # This prevents variable names declared elsewhere (global scope or other
+    # functions) from forcing local first assignments into plain reassignments.
+    child_ctx["var_declared"] = set()
+    child_ctx["_base_declared"] = set()
     child_ctx["globals"] = ctx.setdefault("globals", [])
     child_ctx["helpers"] = helpers_set
     child_ctx["vars"].setdefault("_helpers", helpers_set)

--- a/src/Reduino/transpile/parser.py
+++ b/src/Reduino/transpile/parser.py
@@ -62,6 +62,12 @@ from .ast import (
     DCMotorInvert,
     DCMotorRamp,
     DCMotorRunFor,
+    PWMDriverDecl,
+    PWMDriverSetFrequency,
+    PWMDriverSetDuty,
+    PWMDriverSetLevel,
+    PWMDriverOff,
+    PWMDriverAllOff,
     Program,
     ReturnStmt,
     SerialMonitorDecl,
@@ -641,6 +647,9 @@ def _to_c_expr(
                     buzzer_names = ctx.get("buzzer_names", set())
                     if owner_node.id in buzzer_names:
                         return f"__buzzer_current_{owner_node.id}"
+                    pwm_driver_names = ctx.get("pwm_driver_names", set())
+                    if owner_node.id in pwm_driver_names:
+                        return f"__pwm_frequency_{owner_node.id}"
                 raise ValueError("unsupported attribute call")
 
             if attr == "get_last_frequency":
@@ -688,6 +697,26 @@ def _to_c_expr(
                     motors = ctx.get("dc_motor_names", set())
                     if owner_node.id in motors:
                         return f"__dc_mode_{owner_node.id}"
+                raise ValueError("unsupported attribute call")
+
+            if attr == "get_duty":
+                if len(n.args) != 1 or n.keywords:
+                    raise ValueError("unsupported attribute call")
+                if isinstance(owner_node, ast.Name) and ctx is not None:
+                    pwm_driver_names = ctx.get("pwm_driver_names", set())
+                    if owner_node.id in pwm_driver_names:
+                        channel_expr = emit(n.args[0])
+                        return f"__redu_pwm_get_duty_{owner_node.id}({channel_expr})"
+                raise ValueError("unsupported attribute call")
+
+            if attr == "get_level":
+                if len(n.args) != 1 or n.keywords:
+                    raise ValueError("unsupported attribute call")
+                if isinstance(owner_node, ast.Name) and ctx is not None:
+                    pwm_driver_names = ctx.get("pwm_driver_names", set())
+                    if owner_node.id in pwm_driver_names:
+                        channel_expr = emit(n.args[0])
+                        return f"__redu_pwm_get_level_{owner_node.id}({channel_expr})"
                 raise ValueError("unsupported attribute call")
 
             if attr == "measure_distance":
@@ -1070,6 +1099,30 @@ def _infer_expr_type(
         if attr == "get_brightness" and isinstance(owner, ast.Name):
             if ctx is None:
                 return "int"
+
+        if attr == "get_frequency" and isinstance(owner, ast.Name):
+            if ctx is None:
+                return "float"
+            buzzer_names = ctx.get("buzzer_names", set())
+            if owner.id in buzzer_names:
+                return "float"
+            pwm_driver_names = ctx.get("pwm_driver_names", set())
+            if owner.id in pwm_driver_names:
+                return "float"
+
+        if attr == "get_duty" and isinstance(owner, ast.Name):
+            if ctx is None:
+                return "int"
+            pwm_driver_names = ctx.get("pwm_driver_names", set())
+            if owner.id in pwm_driver_names:
+                return "int"
+
+        if attr == "get_level" and isinstance(owner, ast.Name):
+            if ctx is None:
+                return "float"
+            pwm_driver_names = ctx.get("pwm_driver_names", set())
+            if owner.id in pwm_driver_names:
+                return "float"
             led_names = ctx.get("led_names", set())
             if owner.id in led_names:
                 return "int"
@@ -1374,6 +1427,7 @@ RE_IMPORT_RGB_LED = re.compile(r"^\s*from\s+Reduino\.Actuators\s+import\s+RGBLed
 RE_IMPORT_SERVO   = re.compile(r"^\s*from\s+Reduino\.Actuators\s+import\s+Servo\s*$")
 RE_IMPORT_DC_MOTOR = re.compile(r"^\s*from\s+Reduino\.Actuators\s+import\s+DCMotor\s*$")
 RE_IMPORT_BUZZER  = re.compile(r"^\s*from\s+Reduino\.Actuators\s+import\s+Buzzer\s*$")
+RE_IMPORT_PWM_DRIVER = re.compile(r"^\s*from\s+Reduino\.Actuators\s+import\s+PWMDriver\s*$")
 RE_IMPORT_SLEEP   = re.compile(r"^\s*from\s+Reduino\.Utils\s+import\s+sleep\s*$")
 RE_IMPORT_SERIAL  = re.compile(r"^\s*from\s+Reduino\.Communication\s+import\s+SerialMonitor\s*$")
 RE_IMPORT_TARGET  = re.compile(r"^\s*from\s+Reduino\s+import\s+target\s*$")
@@ -1395,6 +1449,7 @@ RE_BUZZER_DECL = re.compile(r"^\s*([A-Za-z_]\w*)\s*=\s*Buzzer\s*\(\s*(.*?)\s*\)\
 RE_RGB_LED_DECL = re.compile(r"^\s*([A-Za-z_]\w*)\s*=\s*RGBLed\s*\(\s*(.*?)\s*\)\s*$")
 RE_SERVO_DECL = re.compile(r"^\s*([A-Za-z_]\w*)\s*=\s*Servo\s*\(\s*(.*?)\s*\)\s*$")
 RE_DC_MOTOR_DECL = re.compile(r"^\s*([A-Za-z_]\w*)\s*=\s*DCMotor\s*\(\s*(.*?)\s*\)\s*$")
+RE_PWM_DRIVER_DECL = re.compile(r"^\s*([A-Za-z_]\w*)\s*=\s*PWMDriver\s*\(\s*(.*?)\s*\)\s*$")
 RE_ULTRASONIC_DECL = re.compile(r"^\s*([A-Za-z_]\w*)\s*=\s*Ultrasonic\s*\(\s*(.*?)\s*\)\s*$")
 RE_BUTTON_DECL = re.compile(r"^\s*([A-Za-z_]\w*)\s*=\s*Button\s*\(\s*(.*?)\s*\)\s*$")
 RE_POTENTIOMETER_DECL = re.compile(
@@ -1430,6 +1485,11 @@ RE_DC_MOTOR_COAST     = re.compile(r"^\s*([A-Za-z_]\w*)\s*\.coast\(\s*\)\s*$")
 RE_DC_MOTOR_INVERT    = re.compile(r"^\s*([A-Za-z_]\w*)\s*\.invert\(\s*\)\s*$")
 RE_DC_MOTOR_RAMP      = re.compile(r"^\s*([A-Za-z_]\w*)\s*\.ramp\(\s*(.*)\s*\)\s*$")
 RE_DC_MOTOR_RUN_FOR   = re.compile(r"^\s*([A-Za-z_]\w*)\s*\.run_for\(\s*(.*)\s*\)\s*$")
+RE_PWM_DRIVER_SET_FREQUENCY = re.compile(r"^\s*([A-Za-z_]\w*)\s*\.set_frequency\(\s*(.*)\s*\)\s*$")
+RE_PWM_DRIVER_SET_DUTY = re.compile(r"^\s*([A-Za-z_]\w*)\s*\.set_duty\(\s*(.*)\s*\)\s*$")
+RE_PWM_DRIVER_SET_LEVEL = re.compile(r"^\s*([A-Za-z_]\w*)\s*\.set_level\(\s*(.*)\s*\)\s*$")
+RE_PWM_DRIVER_OFF = re.compile(r"^\s*([A-Za-z_]\w*)\s*\.off\(\s*(.*)\s*\)\s*$")
+RE_PWM_DRIVER_ALL_OFF = re.compile(r"^\s*([A-Za-z_]\w*)\s*\.all_off\(\s*\)\s*$")
 
 _BUZZER_MELODIES = {
     "success",
@@ -1755,6 +1815,9 @@ def _handle_assignment_ast(
     def is_dc_motor_call(n: ast.AST) -> bool:
         return isinstance(n, ast.Call) and isinstance(n.func, ast.Name) and n.func.id == "DCMotor"
 
+    def is_pwm_driver_call(n: ast.AST) -> bool:
+        return isinstance(n, ast.Call) and isinstance(n.func, ast.Name) and n.func.id == "PWMDriver"
+
     def is_serial_monitor_call(n: ast.AST) -> bool:
         return (
             isinstance(n, ast.Call)
@@ -1774,6 +1837,7 @@ def _handle_assignment_ast(
         or is_servo_call(value)
         or is_buzzer_call(value)
         or is_dc_motor_call(value)
+        or is_pwm_driver_call(value)
         or is_serial_monitor_call(value)
         or is_ultrasonic_call(value)
         or is_lcd_call(value)
@@ -1786,6 +1850,7 @@ def _handle_assignment_ast(
             or is_servo_call(elt)
             or is_buzzer_call(elt)
             or is_dc_motor_call(elt)
+            or is_pwm_driver_call(elt)
             or is_serial_monitor_call(elt)
             or is_ultrasonic_call(elt)
             or is_lcd_call(elt)
@@ -2213,6 +2278,7 @@ def _parse_simple_lines(
     lcd_tick_names = ctx.setdefault("lcd_tick_names", set())
     servo_names = ctx.setdefault("servo_names", set())
     dc_motor_names = ctx.setdefault("dc_motor_names", set())
+    pwm_driver_names = ctx.setdefault("pwm_driver_names", set())
     buzzer_names = ctx.setdefault("buzzer_names", set())
     button_names = ctx.setdefault("button_names", set())
     button_pins = ctx.setdefault("button_pins", {})
@@ -2362,6 +2428,7 @@ def _parse_simple_lines(
             or RE_IMPORT_SERVO.match(line)
             or RE_IMPORT_DC_MOTOR.match(line)
             or RE_IMPORT_BUZZER.match(line)
+            or RE_IMPORT_PWM_DRIVER.match(line)
             or RE_IMPORT_SLEEP.match(line)
             or RE_IMPORT_SERIAL.match(line)
             or RE_IMPORT_TARGET.match(line)
@@ -3228,6 +3295,29 @@ def _parse_simple_lines(
             i += 1
             continue
 
+        m = RE_PWM_DRIVER_DECL.match(line)
+        if m:
+            name, args_src = m.group(1), m.group(2)
+            i2c_addr = _resolve_numeric_arg(_extract_call_argument(args_src, keyword="i2c_addr"), 0x40)
+            frequency_hz = _resolve_float_arg(
+                _extract_call_argument(args_src, keyword="frequency_hz"), 1000.0
+            )
+            channels = _resolve_numeric_arg(_extract_call_argument(args_src, keyword="channels"), 16)
+            resolution = _resolve_numeric_arg(_extract_call_argument(args_src, keyword="resolution"), 4095)
+            body.append(
+                PWMDriverDecl(
+                    name=name,
+                    i2c_addr=i2c_addr,
+                    frequency_hz=frequency_hz,
+                    channels=channels,
+                    resolution=resolution,
+                )
+            )
+            pwm_driver_names.add(name)
+            vars[name] = _ExprStr(name)
+            i += 1
+            continue
+
         m = RE_RGB_LED_DECL.match(line)
         if m:
             name, args_src = m.group(1), m.group(2)
@@ -3894,6 +3984,98 @@ def _parse_simple_lines(
                         speed=_resolve_float_arg(speed_arg, 0.0),
                     )
                 )
+                i += 1
+                continue
+
+        m = RE_PWM_DRIVER_SET_FREQUENCY.match(line)
+        if m:
+            name, args_src = m.group(1), m.group(2)
+            if name in pwm_driver_names:
+                freq_arg = _extract_call_argument(args_src, keyword="frequency_hz")
+                if freq_arg is None:
+                    freq_arg = _extract_call_argument(args_src)
+                if freq_arg is None or not freq_arg.strip():
+                    raise ValueError("set_frequency requires a frequency_hz argument")
+                body.append(
+                    PWMDriverSetFrequency(
+                        name=name,
+                        frequency_hz=_resolve_float_arg(freq_arg, 1000.0),
+                    )
+                )
+                i += 1
+                continue
+
+        m = RE_PWM_DRIVER_SET_DUTY.match(line)
+        if m:
+            name, args_src = m.group(1), m.group(2)
+            if name in pwm_driver_names:
+                channel_arg = _extract_call_argument(args_src, keyword="channel")
+                if channel_arg is None:
+                    channel_arg = _extract_call_argument(args_src, position=0)
+                value_arg = _extract_call_argument(args_src, keyword="value")
+                if value_arg is None:
+                    value_arg = _extract_call_argument(args_src, position=1)
+                if channel_arg is None or not channel_arg.strip():
+                    raise ValueError("set_duty requires a channel argument")
+                if value_arg is None or not value_arg.strip():
+                    raise ValueError("set_duty requires a value argument")
+                body.append(
+                    PWMDriverSetDuty(
+                        name=name,
+                        channel=_resolve_numeric_arg(channel_arg, 0),
+                        value=_resolve_numeric_arg(value_arg, 0),
+                    )
+                )
+                i += 1
+                continue
+
+        m = RE_PWM_DRIVER_SET_LEVEL.match(line)
+        if m:
+            name, args_src = m.group(1), m.group(2)
+            if name in pwm_driver_names:
+                channel_arg = _extract_call_argument(args_src, keyword="channel")
+                if channel_arg is None:
+                    channel_arg = _extract_call_argument(args_src, position=0)
+                value_arg = _extract_call_argument(args_src, keyword="value")
+                if value_arg is None:
+                    value_arg = _extract_call_argument(args_src, position=1)
+                if channel_arg is None or not channel_arg.strip():
+                    raise ValueError("set_level requires a channel argument")
+                if value_arg is None or not value_arg.strip():
+                    raise ValueError("set_level requires a value argument")
+                body.append(
+                    PWMDriverSetLevel(
+                        name=name,
+                        channel=_resolve_numeric_arg(channel_arg, 0),
+                        value=_resolve_float_arg(value_arg, 0.0),
+                    )
+                )
+                i += 1
+                continue
+
+        m = RE_PWM_DRIVER_OFF.match(line)
+        if m:
+            name, args_src = m.group(1), m.group(2)
+            if name in pwm_driver_names:
+                channel_arg = _extract_call_argument(args_src, keyword="channel")
+                if channel_arg is None:
+                    channel_arg = _extract_call_argument(args_src)
+                if channel_arg is None or not channel_arg.strip():
+                    raise ValueError("off requires a channel argument")
+                body.append(
+                    PWMDriverOff(
+                        name=name,
+                        channel=_resolve_numeric_arg(channel_arg, 0),
+                    )
+                )
+                i += 1
+                continue
+
+        m = RE_PWM_DRIVER_ALL_OFF.match(line)
+        if m:
+            name = m.group(1)
+            if name in pwm_driver_names:
+                body.append(PWMDriverAllOff(name=name))
                 i += 1
                 continue
 

--- a/tests/test_actuators.py
+++ b/tests/test_actuators.py
@@ -373,7 +373,7 @@ class TestPWMDriver:
         assert driver.i2c_addr == 0x40
         assert driver.channels == 16
         assert driver.resolution == 4095
-        assert driver.get_frequency() == pytest.approx(1000.0)
+        assert driver.get_frequency() == pytest.approx(50.0)
 
         driver.set_frequency(60)
         assert driver.get_frequency() == pytest.approx(60.0)

--- a/tests/test_actuators.py
+++ b/tests/test_actuators.py
@@ -7,7 +7,7 @@ from typing import Callable
 
 import pytest
 
-from Reduino.Actuators import Buzzer, DCMotor, Led, RGBLed, Servo
+from Reduino.Actuators import Buzzer, DCMotor, Led, PWMDriver, RGBLed, Servo
 
 
 def _patch_sleep(monkeypatch: pytest.MonkeyPatch, collector: list[float]) -> None:
@@ -362,3 +362,73 @@ class TestServo:
         servo = Servo()
         with pytest.raises(ValueError, match="pulse must be within the configured bounds"):
             servo.write_us(500)
+
+
+class TestPWMDriver:
+    """Tests covering the :class:`Reduino.Actuators.PWMDriver` helper."""
+
+    def test_defaults_and_frequency_controls(self) -> None:
+        driver = PWMDriver()
+
+        assert driver.i2c_addr == 0x40
+        assert driver.channels == 16
+        assert driver.resolution == 4095
+        assert driver.get_frequency() == pytest.approx(1000.0)
+
+        driver.set_frequency(60)
+        assert driver.get_frequency() == pytest.approx(60.0)
+
+    @pytest.mark.parametrize("addr", [-1, 0x80])
+    def test_i2c_address_validation(self, addr: int) -> None:
+        with pytest.raises(ValueError, match="i2c_addr"):
+            PWMDriver(i2c_addr=addr)
+
+    @pytest.mark.parametrize("frequency", [0, -10])
+    def test_frequency_validation(self, frequency: float) -> None:
+        driver = PWMDriver()
+        with pytest.raises(ValueError, match="frequency_hz must be positive"):
+            driver.set_frequency(frequency)
+
+    def test_set_and_get_duty(self) -> None:
+        driver = PWMDriver()
+
+        driver.set_duty(0, 2048)
+        assert driver.get_duty(0) == 2048
+
+        driver.set_level(1, 0.5)
+        assert driver.get_duty(1) == 2048
+        assert driver.get_level(1) == pytest.approx(0.5, abs=1 / 4095)
+
+    @pytest.mark.parametrize("channel", [-1, 16])
+    def test_channel_validation(self, channel: int) -> None:
+        driver = PWMDriver()
+
+        with pytest.raises(ValueError, match="channel out of range"):
+            driver.set_duty(channel, 100)
+
+    @pytest.mark.parametrize("duty", [-1, 4096])
+    def test_duty_validation(self, duty: int) -> None:
+        driver = PWMDriver()
+
+        with pytest.raises(ValueError, match="duty value must be between"):
+            driver.set_duty(0, duty)
+
+    @pytest.mark.parametrize("level", [-0.1, 1.1])
+    def test_level_validation(self, level: float) -> None:
+        driver = PWMDriver()
+
+        with pytest.raises(ValueError, match="level must be between 0.0 and 1.0"):
+            driver.set_level(0, level)
+
+    def test_off_and_all_off_helpers(self) -> None:
+        driver = PWMDriver()
+
+        driver.set_duty(0, 1000)
+        driver.set_duty(1, 2000)
+
+        driver.off(0)
+        assert driver.get_duty(0) == 0
+        assert driver.get_duty(1) == 2000
+
+        driver.all_off()
+        assert all(driver.get_duty(ch) == 0 for ch in range(driver.channels))

--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -362,6 +362,36 @@ def test_emit_serial_monitor_and_variables(src, norm) -> None:
     assert "if ((counter > 10))" in cpp
 
 
+def test_emit_function_local_variables_are_declared_per_function(src, norm) -> None:
+    cpp = compile_source(
+        src(
+            """
+            value = 7
+
+            def angle_to_count(angle):
+                t = (float(angle) + 90.0) / 180.0
+                if t < 0.0:
+                    t = 0.0
+                return int(t * value)
+
+            def another_scale(angle):
+                t = (float(angle) + 45.0) / 90.0
+                if t > 1.0:
+                    t = 1.0
+                return int(t * value)
+
+            out1 = angle_to_count(10)
+            out2 = another_scale(20)
+            """
+        )
+    )
+
+    text = norm(cpp)
+    assert text.count("float t =") == 2
+    assert "t = ((static_cast<float>(angle) + 90.0) / 180.0);" in text
+    assert "t = ((static_cast<float>(angle) + 45.0) / 90.0);" in text
+
+
 def test_emit_for_range_and_try_except(src, norm) -> None:
     cpp = compile_source(
         src(

--- a/tests/test_emitter.py
+++ b/tests/test_emitter.py
@@ -303,6 +303,39 @@ def test_emit_dc_motor_support(src, norm) -> None:
     assert '__dc_mode_motor = F("brake");' in text
 
 
+def test_emit_pwm_driver_support(src, norm) -> None:
+    cpp = compile_source(
+        src(
+            """
+            from Reduino.Actuators import PWMDriver
+
+            driver = PWMDriver(i2c_addr=0x40, frequency_hz=200, channels=16, resolution=4095)
+            driver.set_frequency(1000)
+            driver.set_duty(0, 2048)
+            driver.set_level(1, 0.5)
+            driver.off(1)
+            driver.all_off()
+            duty = driver.get_duty(0)
+            level = driver.get_level(0)
+            """
+        )
+    )
+
+    text = norm(cpp)
+    assert "#include <Wire.h>" in cpp
+    assert "#include <Adafruit_PWMServoDriver.h>" in cpp
+    assert "Adafruit_PWMServoDriver __redu_pwm_driver(" in text
+    assert "float __pwm_frequency_driver = static_cast<float>(200.0);" in text
+    assert "int __pwm_channels_driver = static_cast<int>(16);" in text
+    assert "int __pwm_resolution_driver = static_cast<int>(4095);" in text
+    assert "__redu_pwm_driver.begin();" in text
+    assert "__redu_pwm_driver.setPWMFreq(__pwm_frequency_driver);" in text
+    assert "__redu_pwm_driver.setPWM(__redu_channel, 0, static_cast<int>(__redu_value));" in text
+    assert "for (int __redu_channel = 0; __redu_channel < __pwm_channels_driver; ++__redu_channel)" in text
+    assert "duty = __redu_pwm_get_duty_driver(0);" in text
+    assert "level = __redu_pwm_get_level_driver(0);" in text
+
+
 def test_emit_serial_monitor_and_variables(src, norm) -> None:
     cpp = compile_source(
         src(

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -51,6 +51,12 @@ from Reduino.transpile.ast import (
     DCMotorInvert,
     DCMotorRamp,
     DCMotorRunFor,
+    PWMDriverDecl,
+    PWMDriverSetFrequency,
+    PWMDriverSetDuty,
+    PWMDriverSetLevel,
+    PWMDriverOff,
+    PWMDriverAllOff,
     ReturnStmt,
     SerialMonitorDecl,
     SerialWrite,
@@ -570,6 +576,54 @@ def test_parser_dc_motor_nodes(src) -> None:
         "(__dc_inverted_motor ? -__dc_speed_motor : __dc_speed_motor)" in applied_assigns
     )
     assert "__dc_mode_motor" in mode_assigns
+
+
+def test_parser_pwm_driver_nodes(src) -> None:
+    code = src(
+        """
+        from Reduino.Actuators import PWMDriver
+
+        driver = PWMDriver(i2c_addr=0x40, frequency_hz=200, channels=16, resolution=4095)
+        driver.set_frequency(1000)
+        driver.set_duty(0, 2048)
+        driver.set_level(1, 0.5)
+        driver.off(1)
+        driver.all_off()
+        duty = driver.get_duty(0)
+        level = driver.get_level(0)
+        freq = driver.get_frequency()
+        """
+    )
+
+    program = _parse(code)
+    pwm_nodes = [
+        node for node in program.setup_body if node.__class__.__name__.startswith("PWMDriver")
+    ]
+    assert any(isinstance(node, PWMDriverDecl) for node in pwm_nodes)
+    assert any(isinstance(node, PWMDriverSetFrequency) for node in pwm_nodes)
+    assert any(isinstance(node, PWMDriverSetDuty) for node in pwm_nodes)
+    assert any(isinstance(node, PWMDriverSetLevel) for node in pwm_nodes)
+    assert any(isinstance(node, PWMDriverOff) for node in pwm_nodes)
+    assert any(isinstance(node, PWMDriverAllOff) for node in pwm_nodes)
+
+    duty_assigns = [
+        node.expr
+        for node in program.setup_body
+        if isinstance(node, VarAssign) and node.name == "duty"
+    ]
+    level_assigns = [
+        node.expr
+        for node in program.setup_body
+        if isinstance(node, VarAssign) and node.name == "level"
+    ]
+    freq_assigns = [
+        node.expr
+        for node in program.setup_body
+        if isinstance(node, VarAssign) and node.name == "freq"
+    ]
+    assert "__redu_pwm_get_duty_driver(0)" in duty_assigns
+    assert "__redu_pwm_get_level_driver(0)" in level_assigns
+    assert "__pwm_frequency_driver" in freq_assigns
 
 
 def test_parser_try_statement(src) -> None:

--- a/tests/test_toolchain.py
+++ b/tests/test_toolchain.py
@@ -7,7 +7,7 @@ import pytest
 from Reduino import _collect_required_libraries
 
 from Reduino.toolchain.pio import validate_platform_board, write_project
-from Reduino.transpile.ast import LCDDecl, Program, ServoDecl
+from Reduino.transpile.ast import LCDDecl, PWMDriverDecl, Program, ServoDecl
 
 
 def _read_ini(tmp_path: pathlib.Path) -> str:
@@ -114,3 +114,10 @@ def test_collect_required_libraries_detects_i2c_lcd() -> None:
     )
 
     assert _collect_required_libraries(program) == ["LiquidCrystal_I2C"]
+
+
+def test_collect_required_libraries_detects_pwm_driver() -> None:
+    program = Program(setup_body=[PWMDriverDecl(name="pwm")])
+    assert _collect_required_libraries(program) == [
+        "adafruit/Adafruit PWM Servo Driver Library"
+    ]


### PR DESCRIPTION
### Motivation

- Provide an in-memory, host-testable model of an I2C multi-channel PWM driver (e.g. PCA9685) and expose it via the public actuator API. 
- Allow user Python programs to declare and operate PWM drivers and have those operations transpiled to Arduino C++ (including using the Adafruit PCA9685 library). 
- Add behavioural and emitter/parser tests to validate runtime API and code generation.

### Description

- Add `src/Reduino/Actuators/PWMDriver.py` implementing a hardware-agnostic `PWMDriver` class with frequency, duty/level, channel validation, and helper methods `off`/`all_off`.
- Export `PWMDriver` from `src/Reduino/Actuators/__init__.py` so it is available via `from Reduino.Actuators import PWMDriver`.
- Extend the transpiler AST in `src/Reduino/transpile/ast.py` with `PWMDriverDecl`, `PWMDriverSetFrequency`, `PWMDriverSetDuty`, `PWMDriverSetLevel`, `PWMDriverOff`, and `PWMDriverAllOff` nodes.
- Update the parser in `src/Reduino/transpile/parser.py` to recognize `PWMDriver` declarations and method calls, add regexes for new primitives, infer types for `get_duty`/`get_level`/`get_frequency`, and track `pwm_driver_names` in the parsing context.
- Update the emitter in `src/Reduino/transpile/emitter.py` to emit C++ globals, helper getters, include directives (`Wire` and `Adafruit_PWMServoDriver`), setup initialization and runtime code for `set_frequency`, `set_duty`, `set_level`, `off`, and `all_off`, and to wire PWM state into generated functions.
- Add unit tests covering the runtime API and transpiler integration in `tests/test_actuators.py`, `tests/test_emitter.py`, and `tests/test_parser.py`.

### Testing

- Ran the unit test suite with `pytest` including the new PWM-related tests and the existing actuator/parser/emitter tests.
- Exercised the runtime behaviour via `tests/test_actuators.py::TestPWMDriver` which validates frequency, address/channel/duty/level validation, and `off`/`all_off` behaviour, and it passed.
- Exercised transpiler integration via `tests/test_parser.py::test_parser_pwm_driver_nodes` and `tests/test_emitter.py::test_emit_pwm_driver_support` which validate parsed AST nodes and emitted C++ snippets, and they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d016906cc48326ae999553b0aeb9f3)